### PR TITLE
Handle copyItem where src and dest are within WTFilesystem. Fixes #11

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -25,7 +25,7 @@ from .lib.PathMapper import HomePathMapper, TalePathMapper
 from .lib.WTAssetstoreTypes import WTAssetstoreTypes
 from .lib.WTAssetstoreAdapter import WTHomeAssetstoreAdapter, WTTaleAssetstoreAdapter
 from .lib.EventHandlers import Event, EventHandler, FolderSaveHandler, FolderDeleteHandler
-from .lib.EventHandlers import ItemSaveHandler, AssetstoreQueryHandler
+from .lib.EventHandlers import ItemSaveHandler, AssetstoreQueryHandler, ItemCopyPrepareHandler
 from .resources.homedirpass import Homedirpass
 from girder.utility import assetstore_utilities
 
@@ -152,6 +152,7 @@ def load(info):
     events.bind('model.upload.assetstore', 'wt_home_dir', pathRouter(AssetstoreQueryHandler()))
     events.bind('model.folder.save', 'wt_home_dir', pathRouter(FolderSaveHandler()))
     events.bind('model.item.save', 'wt_home_dir', pathRouter(ItemSaveHandler()))
+    events.bind('model.item.copy.prepare', 'wt_home_dir', pathRouter(ItemCopyPrepareHandler()))
 
     setDefaults()
     addAssetstores()


### PR DESCRIPTION
I think PR#9 somehow broke this functionality. I just added an additional even handler for 'item.copy.prepare' which is triggered only for copying files.