### PR TITLE
Propagate item's name change to underlying file object. Fixes #13

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -24,8 +24,10 @@ from .lib.WTFilesystemProvider import WTFilesystemProvider
 from .lib.PathMapper import HomePathMapper, TalePathMapper
 from .lib.WTAssetstoreTypes import WTAssetstoreTypes
 from .lib.WTAssetstoreAdapter import WTHomeAssetstoreAdapter, WTTaleAssetstoreAdapter
-from .lib.EventHandlers import Event, EventHandler, FolderSaveHandler, FolderDeleteHandler
-from .lib.EventHandlers import ItemSaveHandler, AssetstoreQueryHandler, ItemCopyPrepareHandler
+from .lib.EventHandlers import \
+    Event, EventHandler, FolderSaveHandler, FolderDeleteHandler, \
+    ItemSaveHandler, AssetstoreQueryHandler, ItemCopyPrepareHandler, \
+    ItemCopyAfterHandler
 from .resources.homedirpass import Homedirpass
 from girder.utility import assetstore_utilities
 
@@ -153,6 +155,7 @@ def load(info):
     events.bind('model.folder.save', 'wt_home_dir', pathRouter(FolderSaveHandler()))
     events.bind('model.item.save', 'wt_home_dir', pathRouter(ItemSaveHandler()))
     events.bind('model.item.copy.prepare', 'wt_home_dir', pathRouter(ItemCopyPrepareHandler()))
+    events.bind('model.item.copy.after', 'wt_home_dir', pathRouter(ItemCopyAfterHandler()))
 
     setDefaults()
     addAssetstores()

--- a/server/lib/EventHandlers.py
+++ b/server/lib/EventHandlers.py
@@ -5,6 +5,7 @@ from wsgidav.dav_provider import DAVCollection
 from wsgidav.fs_dav_provider import FileResource
 from girder.events import Event
 from girder.utility import path as path_util
+from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
 from . WTFilesystemProvider import WTFilesystemProvider, WT_HOME_FLAG
@@ -212,6 +213,20 @@ class ItemCopyPrepareHandler(EventHandler):
         res = self.getResourceInstance(girderSrcPath, pathMapper, provider)
         self.assertIsValidFile(res, girderSrcPath)
         FileResource.copyMoveSingle(res, davDstPath.as_posix(), False)
+
+
+class ItemCopyAfterHandler(EventHandler):
+    def getResourceType(self, event: Event):
+        return 'item'
+
+    def getResource(self, event: Event):
+        return event.info
+
+    def run(self, event: Event, path: pathlib.Path, pathMapper, provider: WTFilesystemProvider):
+        item = self.getResource(event)
+        for file in Item().childFiles(item=item):
+            file['name'] = item['name']
+            File().updateFile(file)
 
 
 class AssetstoreQueryHandler(EventHandler):

--- a/server/lib/WTFilesystemProvider.py
+++ b/server/lib/WTFilesystemProvider.py
@@ -261,22 +261,33 @@ class WTFileResource(_WTDAVResource, FileResource):
         itemDoc = self._girderLookup(self._refToGirderPath())
         destGirderParentPath = self.pathMapper.davToGirder(os.path.dirname(destPath))
         girderDestDoc = self._girderLookup(destGirderParentPath)
-        Item().copyItem(srcItem=itemDoc, creator=self.getUser(), name=os.path.basename(destPath),
-                        folder=girderDestDoc, description=WT_HOME_FLAG)
+        item = Item().copyItem(
+            srcItem=itemDoc, creator=self.getUser(), name=os.path.basename(destPath),
+            folder=girderDestDoc, description=WT_HOME_FLAG)
+        self._unifyName(item)
 
     def moveRecursive(self, destPath):
         FileResource.moveRecursive(self, destPath)
         self._girderMoveOrRename(destPath)
 
+    def _unifyName(self, item):
+        for file in Item().childFiles(item=item):
+            file['name'] = item['name']
+            File().updateFile(file)
+
     def _girderUpdateModel(self, doc):
-        Item().updateItem(doc)
+        item = Item().updateItem(doc)
+        self._unifyName(item)
 
     def _girderModelCopy(self, srcDoc, destDoc, destPath):
-        Item().copyItem(srcItem=srcDoc, creator=self.getUser(), parent=destDoc,
-                        name=os.path.basename(destPath), description=WT_HOME_FLAG)
+        item = Item().copyItem(
+            srcItem=srcDoc, creator=self.getUser(), parent=destDoc,
+            name=os.path.basename(destPath), description=WT_HOME_FLAG)
+        self._unifyName(item)
 
     def _girderModelMove(self, doc, destDoc):
-        Item().move(doc, destDoc)
+        item = Item().move(doc, destDoc)
+        self._unifyName(item)
 
 
 # Adds support for 'executable' property


### PR DESCRIPTION
This is a rather ugly change necessary to keep File/Item duo in sync.