### PR TITLE
 Propagate file size change to Girder objects. Fixes #15

### DIFF
--- a/server/lib/WTFilesystemProvider.py
+++ b/server/lib/WTFilesystemProvider.py
@@ -245,11 +245,13 @@ class WTFileResource(_WTDAVResource, FileResource):
             file = File().createFile(
                 name=self.name, creator=self.getUser(), item=itemDoc, reuseExisting=True,
                 size=stat.st_size, assetstore=FSProvider.assetstore, saveFile=False)
+            file['size'] = stat.st_size
             file['path'] = self._filePath
             file['mtime'] = stat.st_mtime
             file['description'] = WT_HOME_FLAG
             # file['imported'] = True
             File().save(file)
+            Item().recalculateSize(itemDoc)
         except ResourcePathNotFound:
             pass  # TODO: do something about it?
 


### PR DESCRIPTION
`File().createFile()` with `reuseExisting=True` basically acts as `load()` if file already exists. `size` parameter in that case is completely ignored. This PR ensures that size attribute reflects `stat.st_size` and any changes are propagated upwards to Item, parent Folder/Collections.