### PR TITLE
 Add OPTIONS to methods allowed by DAV:read privilege

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "WholeTale Home Directory Plugin",
     "description": "Uses WsgiDAV to provide a WebDAV-accessible directory for each user",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "dependencies": ["wholetale"]
 }

--- a/server/lib/Authorizer.py
+++ b/server/lib/Authorizer.py
@@ -6,7 +6,7 @@ import pathlib
 
 _logger = util.getModuleLogger(__name__, True)
 
-DAV_READ_OPS = set(['HEAD', 'GET', 'PROPFIND'])
+DAV_READ_OPS = set(['HEAD', 'GET', 'PROPFIND', 'OPTIONS'])
 
 
 class Authorizer(BaseMiddleware):


### PR DESCRIPTION
I was trying to mount a workspace as user that has read only access, but that raised `girder.exceptions` while accessing the Tale. After short debugging I found that `DAV_READ_OPTS` is missing verb `OPTIONS`. As per [WebDAV standard](https://www.ietf.org/rfc/rfc3744.txt):

```
3.1.  DAV:read Privilege

   The read privilege controls methods that return information about the
   state of the resource, including the resource's properties.  Affected
   methods include GET and PROPFIND.  Any implementation-defined
   privilege that also controls access to GET and PROPFIND must be
   aggregated under DAV:read - if an ACL grants access to DAV:read, the
   client may expect that no other privilege needs to be granted to have
   access to GET and PROPFIND.  Additionally, the read privilege MUST
   control the OPTIONS method.
```