### PR TITLE
Https fix

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -121,7 +121,7 @@ def startDAVServer(rootPath, directoryInitializer, authorizer, pathMapper, asset
     global HOME_DIRS_APPS
     app = WsgiDAVApp(config)
     HOME_DIRS_APPS.add(realm, pathMapper, app)
-    cherrypy.tree.graft(WsgiDAVApp(config), '/' + realm)
+    cherrypy.tree.graft(app, '/' + realm)
 
 
 def setDefaults():

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -89,6 +89,13 @@ def pathRouter(h: EventHandler):
     return handler
 
 
+class WTDAVApp(WsgiDAVApp):
+    def __call__(self, environ, start_response):
+        if 'HTTP_X_FORWARDED_PROTO' in environ:
+            environ['wsgi.url_scheme'] = environ['HTTP_X_FORWARDED_PROTO']
+        return super().__call__(environ, start_response)
+
+
 def startDAVServer(rootPath, directoryInitializer, authorizer, pathMapper, assetstoreType: int):
     if not os.path.exists(rootPath):
         os.makedirs(rootPath)
@@ -119,7 +126,7 @@ def startDAVServer(rootPath, directoryInitializer, authorizer, pathMapper, asset
     if 'GIRDER_TEST_ASSETSTORE' in os.environ:
         config.update({'verbose': 2})
     global HOME_DIRS_APPS
-    app = WsgiDAVApp(config)
+    app = WTDAVApp(config)
     HOME_DIRS_APPS.add(realm, pathMapper, app)
     cherrypy.tree.graft(app, '/' + realm)
 


### PR DESCRIPTION
This is meant to address #18. It looks like none of the trickery I tried can convince the stack we have to set the wsgi.url_scheme to what is externally visible if behind a proxy. This commit checks if the X-Forwarded-Proto header is set and, if so, sets wsgi.url_scheme to the value of X-Forwarded-Proto.

My apache does not automatically add X-Forwarded-Proto when used as a proxy, so, for this solution to work, some additional incantation in the proxy configuration may be required. I my case, this is simply 'RequestHeader set X-Forwarded-Proto "https"' for the proxy virtual site. 

This may or may not have security implications. I can imagine that, if the DAV server uses wsgi.url_scheme to, for example, only allow basic authentication when 'https' is used, a malicious client could set the X-Forwarded-Proto to 'https' even when issuing a request through http, thus convincing our stack to allow basic authentication with http. This will, of course, not occur if we disable http access to the DAV stuff. Nor is this example a particular problem: if the user really wants to send their credentials unencrypted, they can do so regardless of what we enforce. I.e., they could simply put the credentials on a web page. But, anyway, there may be other scenarios and I did not consider, so we should keep that in mind.