### PR TITLE
Ensure that physical root of a workspace exists, while copying items.

### DIFF
--- a/server/lib/EventHandlers.py
+++ b/server/lib/EventHandlers.py
@@ -212,7 +212,15 @@ class ItemCopyPrepareHandler(EventHandler):
         davDstPath = pathMapper.girderToDav(girderDstPath)
         res = self.getResourceInstance(girderSrcPath, pathMapper, provider)
         self.assertIsValidFile(res, girderSrcPath)
-        FileResource.copyMoveSingle(res, davDstPath.as_posix(), False)
+
+        try:
+            FileResource.copyMoveSingle(res, davDstPath.as_posix(), False)
+        except FileNotFoundError:
+            # Under certain conditions (whole-tale/wt_home_dirs#21) root path
+            # doesn't exist. Create it and try copying again.
+            path = self.getPhysicalPath(girderDstPath, pathMapper, provider)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            FileResource.copyMoveSingle(res, davDstPath.as_posix(), False)
 
 
 class ItemCopyAfterHandler(EventHandler):


### PR DESCRIPTION
Fixes #21 

If copying item fails, try to create destination root path directory on physical storage and try again.