### PR TITLE
Write permission should be sufficient for rw ops in the workspace

### DIFF
--- a/server/lib/Authorizer.py
+++ b/server/lib/Authorizer.py
@@ -95,7 +95,7 @@ class TaleAuthorizer(Authorizer):
         if self.isReadOp(environ):
             access_level = AccessType.READ
         else:
-            access_level = AccessType.ADMIN
+            access_level = AccessType.WRITE
 
         try:
             tale = self.taleModel.load(taleId, user=user, level=access_level, exc=True)


### PR DESCRIPTION
Per issue reported by @craig-willis on [yesterday's meeting](https://wholetale.readthedocs.io/en/latest/development/meetings/2020-11-23.html) write access level on a Tale was insufficient to write files into the workspace using webdav mount. This PR fixes that. 