### PR TITLE
Append 'workspaceId' to a Tale during the 'create' event

### DIFF
--- a/plugin_tests/wt_home_dir_test.py
+++ b/plugin_tests/wt_home_dir_test.py
@@ -385,7 +385,7 @@ class IntegrationTestCase(base.TestCase):
         base.TestCase.setUp(self)
         from girder.plugins.wt_home_dir import HOME_DIRS_APPS
         self.homeDirsApps = HOME_DIRS_APPS  # nopep8
-        from girder.plugins.wholetale.constants import WORKSPACE_NAME
+        from girder.plugins.wt_home_dir.constants import WORKSPACE_NAME
         global WORKSPACE_NAME
         # We need to recreate DirectFS assetstore, which was dropped in
         # base.TestCase.setUp...

--- a/server/constants.py
+++ b/server/constants.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+WORKSPACE_NAME = "WholeTale Workspaces"
+
 
 class PluginSettings:
-    HOME_DIRS_ROOT = 'wthome.homedir_root'
-    TALE_DIRS_ROOT = 'wthome.taledir_root'
+    HOME_DIRS_ROOT = "wthome.homedir_root"
+    TALE_DIRS_ROOT = "wthome.taledir_root"

--- a/server/lib/PathMapper.py
+++ b/server/lib/PathMapper.py
@@ -1,6 +1,6 @@
 import pathlib
 from typing import Union
-from girder.plugins.wholetale.constants import WORKSPACE_NAME
+from ..constants import WORKSPACE_NAME
 
 
 class PathMapper:


### PR DESCRIPTION
Handle creation of the workspace during `tale.created` event. Also ports `Workspace` resource to this plugin, but I need to check if it's really used anywhere...