### PR TITLE
Remove workspace in an event a Tale is removed

### DIFF
--- a/plugin_tests/wt_home_dir_test.py
+++ b/plugin_tests/wt_home_dir_test.py
@@ -788,3 +788,14 @@ class IntegrationTestCase(base.TestCase):
                 user=self.user)
             self.assertStatusOk(resp)
             self.assertFalse(os.path.isdir(fAbsPath))
+
+    def testWorkspaceRemoval(self):
+        from girder.plugins.wholetale.models.tale import Tale
+        from girder.models.folder import Folder
+        tale = self.createTale(self.user, public=False)
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        self.assertTrue(os.path.isdir(workspace["fsPath"]))
+        Tale().remove(tale)
+        self.assertFalse(os.path.isdir(workspace["fsPath"]))
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        self.assertEqual(workspace, None)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -4,6 +4,7 @@
 import cherrypy
 import os
 import pathlib
+import shutil
 import tempfile
 from wsgidav.wsgidav_app import DEFAULT_CONFIG, WsgiDAVApp
 from wsgidav.dir_browser import WsgiDavDirBrowser
@@ -157,6 +158,14 @@ def setTaleFolderMapping(event: events.Event):
     event.addResponse(tale)
 
 
+def deleteWorkspace(event: events.Event):
+    tale = event.info
+    if (workspace := Folder().load(tale["workspaceId"], force=True)):
+        if "fsPath" in workspace:
+            shutil.rmtree(workspace["fsPath"])
+        Folder().remove(workspace)
+
+
 def load(info):
     setDefaults()
 
@@ -173,6 +182,7 @@ def load(info):
     events.unbind('model.user.save.created', CoreEventHandler.USER_DEFAULT_FOLDERS)
     events.bind('model.user.save.created', 'wt_home_dirs', setHomeFolderMapping)
     events.bind('model.tale.save.created', 'wt_home_dirs', setTaleFolderMapping)
+    events.bind('model.tale.remove', 'wt_home_dirs', deleteWorkspace)
 
     hdp = Homedirpass()
     info['apiRoot'].homedirpass = hdp


### PR DESCRIPTION
Creation of a workspace is already handled in this plugin via event. Same should apply to removal.